### PR TITLE
Amazon AWS Elasticsearch Service Request Signing

### DIFF
--- a/mongo_connector/doc_managers/elastic_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic_doc_manager.py
@@ -24,7 +24,7 @@ from threading import Timer
 
 import bson.json_util
 
-from elasticsearch import Elasticsearch, exceptions as es_exceptions
+from elasticsearch import Elasticsearch, exceptions as es_exceptions, connection as es_connection
 from elasticsearch.helpers import scan, streaming_bulk
 
 from mongo_connector import errors
@@ -34,6 +34,8 @@ from mongo_connector.constants import (DEFAULT_COMMIT_INTERVAL,
 from mongo_connector.util import exception_wrapper, retry_until_ok
 from mongo_connector.doc_managers.doc_manager_base import DocManagerBase
 from mongo_connector.doc_managers.formatters import DefaultDocumentFormatter
+
+from requests_aws4auth import AWS4Auth
 
 wrap_exceptions = exception_wrapper({
     es_exceptions.ConnectionError: errors.ConnectionFailed,
@@ -55,8 +57,16 @@ class DocManager(DocManagerBase):
                  unique_key='_id', chunk_size=DEFAULT_MAX_BULK,
                  meta_index_name="mongodb_meta", meta_type="mongodb_meta",
                  attachment_field="content", **kwargs):
+        aws = kwargs.get('aws', {'access_id': '', 'secret_key': '', 'region': 'us-east-1'})
+        client_options = kwargs.get('clientOptions', {})
+        if 'aws' in kwargs:
+            aws_auth = AWS4Auth(aws['access_id'], aws['secret_key'], aws['region'], 'es')
+            client_options['http_auth'] = aws_auth
+            client_options['use_ssl'] = True
+            client_options['verify_certs'] = True
+            client_options['connection_class'] = es_connection.RequestsHttpConnection
         self.elastic = Elasticsearch(
-            hosts=[url], **kwargs.get('clientOptions', {}))
+            hosts=[url], **client_options))
         self.auto_commit_interval = auto_commit_interval
         self.meta_index_name = meta_index_name
         self.meta_type = meta_type

--- a/mongo_connector/doc_managers/elastic_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic_doc_manager.py
@@ -66,7 +66,7 @@ class DocManager(DocManagerBase):
             client_options['verify_certs'] = True
             client_options['connection_class'] = es_connection.RequestsHttpConnection
         self.elastic = Elasticsearch(
-            hosts=[url], **client_options))
+            hosts=[url], **client_options)
         self.auto_commit_interval = auto_commit_interval
         self.meta_index_name = meta_index_name
         self.meta_type = meta_type

--- a/mongo_connector/doc_managers/elastic_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic_doc_manager.py
@@ -57,9 +57,9 @@ class DocManager(DocManagerBase):
                  unique_key='_id', chunk_size=DEFAULT_MAX_BULK,
                  meta_index_name="mongodb_meta", meta_type="mongodb_meta",
                  attachment_field="content", **kwargs):
-        aws = kwargs.get('aws', {'access_id': '', 'secret_key': '', 'region': 'us-east-1'})
         client_options = kwargs.get('clientOptions', {})
         if 'aws' in kwargs:
+            aws = kwargs.get('aws', {'access_id': '', 'secret_key': '', 'region': 'us-east-1'})
             aws_auth = AWS4Auth(aws['access_id'], aws['secret_key'], aws['region'], 'es')
             client_options['http_auth'] = aws_auth
             client_options['use_ssl'] = True

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 import sys
 
 test_suite = "tests"
-tests_require = ["mongo-orchestration>= 0.2, < 0.4", "requests>=2.5.1"]
+tests_require = ["mongo-orchestration>= 0.2, < 0.4", "requests >= 2.5.1", "requests-aws4auth >= 0.7"]
 
 if sys.version_info[:2] == (2, 6):
     # Need unittest2 to run unittests in Python 2.6
@@ -30,7 +30,7 @@ setup(name='elastic-doc-manager',
       author_email='mongodb-user@googlegroups.com',
       url='https://github.com/mongodb-labs/elastic-doc-manager',
       packages=["mongo_connector", "mongo_connector.doc_managers"],
-      install_requires=['mongo-connector >= 2.3.0', 'elasticsearch >= 1.2, < 2.0.0', 'requests', 'requests-aws4auth >= 0.7'],
+      install_requires=['mongo-connector >= 2.3.0', 'elasticsearch >= 1.2, < 2.0.0', 'requests >= 2.5.1', 'requests-aws4auth >= 0.7'],
       license="Apache License, Version 2.0",
       classifiers=[
           "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(name='elastic-doc-manager',
       author_email='mongodb-user@googlegroups.com',
       url='https://github.com/mongodb-labs/elastic-doc-manager',
       packages=["mongo_connector", "mongo_connector.doc_managers"],
-      install_requires=['mongo-connector >= 2.3.0', 'elasticsearch >= 1.2, < 2.0.0'],
+      install_requires=['mongo-connector >= 2.3.0', 'elasticsearch >= 1.2, < 2.0.0', 'requests', 'aws4auth >= 0.7'],
       license="Apache License, Version 2.0",
       classifiers=[
           "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(name='elastic-doc-manager',
       author_email='mongodb-user@googlegroups.com',
       url='https://github.com/mongodb-labs/elastic-doc-manager',
       packages=["mongo_connector", "mongo_connector.doc_managers"],
-      install_requires=['mongo-connector >= 2.3.0', 'elasticsearch >= 1.2, < 2.0.0', 'requests', 'aws4auth >= 0.7'],
+      install_requires=['mongo-connector >= 2.3.0', 'elasticsearch >= 1.2, < 2.0.0', 'requests', 'requests-aws4auth >= 0.7'],
       license="Apache License, Version 2.0",
       classifiers=[
           "Development Status :: 4 - Beta",


### PR DESCRIPTION
This addition allows the definition of connector `args` for `aws` that allow requests to Amazon Elasticsearch Service to be signed.

Documentation on the [mongo-connector Elasticsearch wiki page](https://github.com/mongodb-labs/mongo-connector/wiki/Usage-with-ElasticSearch) will need to be changed to add in instructions for signing after this PR is merged (which I'll be happy to perform).
