### PR TITLE
feature/aws-request-signing

### DIFF
--- a/mongo_connector/doc_managers/elastic_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic_doc_manager.py
@@ -24,7 +24,7 @@ from threading import Timer
 
 import bson.json_util
 
-from elasticsearch import Elasticsearch, exceptions as es_exceptions
+from elasticsearch import Elasticsearch, exceptions as es_exceptions, connection as es_connection
 from elasticsearch.helpers import scan, streaming_bulk
 
 from mongo_connector import errors
@@ -34,6 +34,8 @@ from mongo_connector.constants import (DEFAULT_COMMIT_INTERVAL,
 from mongo_connector.util import exception_wrapper, retry_until_ok
 from mongo_connector.doc_managers.doc_manager_base import DocManagerBase
 from mongo_connector.doc_managers.formatters import DefaultDocumentFormatter
+from requests_aws_sign import AWSV4Sign
+from boto3 import session
 
 wrap_exceptions = exception_wrapper({
     es_exceptions.ConnectionError: errors.ConnectionFailed,
@@ -55,8 +57,25 @@ class DocManager(DocManagerBase):
                  unique_key='_id', chunk_size=DEFAULT_MAX_BULK,
                  meta_index_name="mongodb_meta", meta_type="mongodb_meta",
                  attachment_field="content", **kwargs):
+        client_options = kwargs.get('clientOptions', {})
+        if 'aws' in kwargs:
+            aws = kwargs.get('aws', {'access_id': '', 'secret_key': '', 'region': 'us-east-1'})
+            session = session.Session()
+            if (aws['access_id'] and aws['secret_key']) {
+                session = session.Session(
+                    aws_access_key_id = aws['access_id'],
+                    aws_secret_access_key = aws['secret_key']
+                )
+            }
+            credentials = session.get_credentials()
+            region = session.region_name or aws['region']
+            aws_auth = AWSV4Sign(credentials, region, 'es')
+            client_options['http_auth'] = aws_auth
+            client_options['use_ssl'] = True
+            client_options['verify_certs'] = True
+            client_options['connection_class'] = es_connection.RequestsHttpConnection
         self.elastic = Elasticsearch(
-            hosts=[url], **kwargs.get('clientOptions', {}))
+            hosts=[url], **client_options)
         self.auto_commit_interval = auto_commit_interval
         self.meta_index_name = meta_index_name
         self.meta_type = meta_type

--- a/mongo_connector/doc_managers/elastic_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic_doc_manager.py
@@ -61,7 +61,7 @@ class DocManager(DocManagerBase):
         if 'aws' in kwargs:
             aws = kwargs.get('aws', {'access_id': '', 'secret_key': '', 'region': 'us-east-1'})
             aws_session = session.Session()
-            if aws['access_id'] and aws['secret_key']:
+            if 'access_id' in aws and 'secret_key' in aws:
                 aws_session = session.Session(
                     aws_access_key_id = aws['access_id'],
                     aws_secret_access_key = aws['secret_key']

--- a/mongo_connector/doc_managers/elastic_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic_doc_manager.py
@@ -60,15 +60,14 @@ class DocManager(DocManagerBase):
         client_options = kwargs.get('clientOptions', {})
         if 'aws' in kwargs:
             aws = kwargs.get('aws', {'access_id': '', 'secret_key': '', 'region': 'us-east-1'})
-            session = session.Session()
-            if (aws['access_id'] and aws['secret_key']) {
-                session = session.Session(
+            aws_session = session.Session()
+            if aws['access_id'] and aws['secret_key']:
+                aws_session = session.Session(
                     aws_access_key_id = aws['access_id'],
                     aws_secret_access_key = aws['secret_key']
                 )
-            }
-            credentials = session.get_credentials()
-            region = session.region_name or aws['region']
+            credentials = aws_session.get_credentials()
+            region = aws_session.region_name or aws['region']
             aws_auth = AWSV4Sign(credentials, region, 'es')
             client_options['http_auth'] = aws_auth
             client_options['use_ssl'] = True

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(name='elastic-doc-manager',
       author_email='mongodb-user@googlegroups.com',
       url='https://github.com/mongodb-labs/elastic-doc-manager',
       packages=["mongo_connector", "mongo_connector.doc_managers"],
-      install_requires=['mongo-connector >= 2.3.0', 'elasticsearch >= 1.2, < 2.0.0', 'boto3 >= 1.4.0', 'requests-aws-sign >= 0.1.1'],
+      install_requires=['mongo-connector >= 2.3.0', 'elasticsearch >= 1.2, < 2.0.0'],
+	  extras_require={'aws': ['boto3 >= 1.4.0', 'requests-aws-sign >= 0.1.1']}
       license="Apache License, Version 2.0",
       classifiers=[
           "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 import sys
 
 test_suite = "tests"
-tests_require = ["mongo-orchestration>= 0.2, < 0.4", "requests>=2.5.1"]
+tests_require = ["mongo-orchestration >= 0.2, < 0.4", "requests >= 2.5.1", "boto3 >= 1.4.0", "requests-aws-sign >= 0.1.1"]
 
 if sys.version_info[:2] == (2, 6):
     # Need unittest2 to run unittests in Python 2.6
@@ -30,7 +30,7 @@ setup(name='elastic-doc-manager',
       author_email='mongodb-user@googlegroups.com',
       url='https://github.com/mongodb-labs/elastic-doc-manager',
       packages=["mongo_connector", "mongo_connector.doc_managers"],
-      install_requires=['mongo-connector >= 2.3.0', 'elasticsearch >= 1.2, < 2.0.0'],
+      install_requires=['mongo-connector >= 2.3.0', 'elasticsearch >= 1.2, < 2.0.0', 'boto3 >= 1.4.0', 'requests-aws-sign >= 0.1.1'],
       license="Apache License, Version 2.0",
       classifiers=[
           "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='elastic-doc-manager',
       url='https://github.com/mongodb-labs/elastic-doc-manager',
       packages=["mongo_connector", "mongo_connector.doc_managers"],
       install_requires=['mongo-connector >= 2.3.0', 'elasticsearch >= 1.2, < 2.0.0'],
-	  extras_require={'aws': ['boto3 >= 1.4.0', 'requests-aws-sign >= 0.1.1']}
+	  extras_require={'aws': ['boto3 >= 1.4.0', 'requests-aws-sign >= 0.1.1']},
       license="Apache License, Version 2.0",
       classifiers=[
           "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 import sys
 
 test_suite = "tests"
-tests_require = ["mongo-orchestration >= 0.2, < 0.4", "requests >= 2.5.1", "boto3 >= 1.4.0", "requests-aws-sign >= 0.1.1"]
+tests_require = ["mongo-orchestration >= 0.2, < 0.4", "requests >= 2.5.1"]
 
 if sys.version_info[:2] == (2, 6):
     # Need unittest2 to run unittests in Python 2.6


### PR DESCRIPTION
Hey @llvtt and @sha1sum I went ahead and took a shot implementing the feature discussed here #2 with a different library [jmenga/requests-aws-sign](https://github.com/jmenga/requests-aws-sign). This way, AWS clients can authenticate and sign requests as defined [here](https://boto3.readthedocs.io/en/latest/guide/configuration.html?highlight=metadata). For example in your mongo-connector config file you could do something like this:

```
{
    "mainAddress": "mongodb://admin:password@mongourl/admin?replicaSet=rs0",
    "namespaces": {
        "include": ["mydb.collection"]
    },
    "docManagers": [{
        "docManager": "elastic_doc_manager",
        "targetURL": "https://elasticsearch:9200",
        "args": {
            "aws": {
                "region": "us-east-1"
            }
        }
    }]
}
```

And the library will attempt to authenticate with either `~/.aws/config` or via ec2 metadata. Or you can explicitly set your credentials like this:

```
{
    "mainAddress": "mongodb://admin:password@mongourl/admin?replicaSet=rs0",
    "namespaces": {
        "include": ["mydb.collection"]
    },
    "docManagers": [{
        "docManager": "elastic_doc_manager",
        "targetURL": "https://elasticsearch:9200",
        "args": {
            "aws": {
                "access_id": "ACCESS_ID",
                "secret_key": "SECRET_KEY",
                "region": "us-east-1"
            }
        }
    }]
}
```

As I mentioned before I am not a python guy so please let me know if any of my code doesn't follow best practices or you spot something I overlooked.
