### PR TITLE
Amazon AWS Elasticsearch Service Request Signing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
 before_script:
   - sudo service elasticsearch restart
   - mongo-orchestration start
+  - sleep 10
   - sudo lsof -n -iTCP:9200
   - sudo lsof -n -iTCP:8889
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ install:
 before_script:
   - sudo service elasticsearch restart
   - mongo-orchestration start
+  - sudo lsof -n -iTCP:9200
+  - sudo lsof -n -iTCP:8889
 
 script:
   - python setup.py test

--- a/mongo_connector/doc_managers/elastic_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic_doc_manager.py
@@ -24,7 +24,7 @@ from threading import Timer
 
 import bson.json_util
 
-from elasticsearch import Elasticsearch, exceptions as es_exceptions
+from elasticsearch import Elasticsearch, exceptions as es_exceptions, connection as es_connection
 from elasticsearch.helpers import scan, streaming_bulk
 
 from mongo_connector import errors
@@ -34,6 +34,8 @@ from mongo_connector.constants import (DEFAULT_COMMIT_INTERVAL,
 from mongo_connector.util import exception_wrapper, retry_until_ok
 from mongo_connector.doc_managers.doc_manager_base import DocManagerBase
 from mongo_connector.doc_managers.formatters import DefaultDocumentFormatter
+from requests_aws_sign import AWSV4Sign
+from boto3 import session
 
 wrap_exceptions = exception_wrapper({
     es_exceptions.ConnectionError: errors.ConnectionFailed,
@@ -55,8 +57,25 @@ class DocManager(DocManagerBase):
                  unique_key='_id', chunk_size=DEFAULT_MAX_BULK,
                  meta_index_name="mongodb_meta", meta_type="mongodb_meta",
                  attachment_field="content", **kwargs):
+        client_options = kwargs.get('clientOptions', {})
+        if 'aws' in kwargs:
+            aws = kwargs.get('aws', {'access_id': '', 'secret_key': '', 'region': 'us-east-1'})
+            session = session.Session()
+            if (aws['access_id'] and aws['secret_key']) {
+                session = session.Session(
+                    aws_access_key_id = aws['access_id'],
+                    aws_secret_access_key = aws['secret_key']
+                )
+            }
+            credentials = session.get_credentials()
+            region = session.region_name or aws['region']
+            aws_auth = AWSV4Sign(credentials, region, 'es')
+            client_options['http_auth'] = aws_auth
+            client_options['use_ssl'] = True
+            client_options['verify_certs'] = True
+            client_options['connection_class'] = es_connection.RequestsHttpConnection
         self.elastic = Elasticsearch(
-            hosts=[url], **kwargs.get('clientOptions', {}))
+            hosts=[url], **client_options)
         self.auto_commit_interval = auto_commit_interval
         self.meta_index_name = meta_index_name
         self.meta_type = meta_type

--- a/mongo_connector/doc_managers/elastic_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic_doc_manager.py
@@ -61,7 +61,7 @@ class DocManager(DocManagerBase):
         if 'aws' in kwargs:
             aws = kwargs.get('aws', {'access_id': '', 'secret_key': '', 'region': 'us-east-1'})
             aws_session = session.Session()
-            if aws['access_id'] and aws['secret_key']:
+            if 'access_id' in aws and 'secret_key' in aws:
                 aws_session = session.Session(
                     aws_access_key_id = aws['access_id'],
                     aws_secret_access_key = aws['secret_key']

--- a/mongo_connector/doc_managers/elastic_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic_doc_manager.py
@@ -60,15 +60,14 @@ class DocManager(DocManagerBase):
         client_options = kwargs.get('clientOptions', {})
         if 'aws' in kwargs:
             aws = kwargs.get('aws', {'access_id': '', 'secret_key': '', 'region': 'us-east-1'})
-            session = session.Session()
-            if (aws['access_id'] and aws['secret_key']) {
-                session = session.Session(
+            aws_session = session.Session()
+            if aws['access_id'] and aws['secret_key']:
+                aws_session = session.Session(
                     aws_access_key_id = aws['access_id'],
                     aws_secret_access_key = aws['secret_key']
                 )
-            }
-            credentials = session.get_credentials()
-            region = session.region_name or aws['region']
+            credentials = aws_session.get_credentials()
+            region = aws_session.region_name or aws['region']
             aws_auth = AWSV4Sign(credentials, region, 'es')
             client_options['http_auth'] = aws_auth
             client_options['use_ssl'] = True

--- a/mongo_connector/doc_managers/elastic_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic_doc_manager.py
@@ -38,7 +38,7 @@ from mongo_connector.doc_managers.formatters import DefaultDocumentFormatter
 _HAS_AWS = True
 try:
     from requests_aws_sign import AWSV4Sign
-    from boto3 import session
+    from boto3 import session as aws_session
 except ImportError:
     _HAS_AWS = False
 
@@ -65,15 +65,15 @@ class DocManager(DocManagerBase):
         client_options = kwargs.get('clientOptions', {})
         if 'aws' in kwargs:
             if _HAS_AWS is False:
-                raise ConfigurationError('aws must be installed to sign elasticsearch requests')
-            aws = kwargs.get('aws', {'access_id': '', 'secret_key': '', 'region': 'us-east-1'})
-            aws_session = session.Session()
-            if 'access_id' in aws and 'secret_key' in aws:
-                aws_session = session.Session(
-                    aws_access_key_id = aws['access_id'],
-                    aws_secret_access_key = aws['secret_key'])
-            credentials = aws_session.get_credentials()
-            region = aws_session.region_name or aws['region']
+                raise ConfigurationError('aws extras must be installed to sign Elasticsearch requests')
+            aws_args = kwargs.get('aws', {'region': 'us-east-1'})
+            aws = aws_session.Session()
+            if 'access_id' in aws_args and 'secret_key' in aws_args:
+                aws = aws_session.Session(
+                    aws_access_key_id = aws_args['access_id'],
+                    aws_secret_access_key = aws_args['secret_key'])
+            credentials = aws.get_credentials()
+            region = aws.region_name or aws_args['region']
             aws_auth = AWSV4Sign(credentials, region, 'es')
             client_options['http_auth'] = aws_auth
             client_options['use_ssl'] = True

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(name='elastic-doc-manager',
       author_email='mongodb-user@googlegroups.com',
       url='https://github.com/mongodb-labs/elastic-doc-manager',
       packages=["mongo_connector", "mongo_connector.doc_managers"],
-      install_requires=['mongo-connector >= 2.3.0', 'elasticsearch >= 1.2, < 2.0.0', 'boto3 >= 1.4.0', 'requests-aws-sign >= 0.1.1'],
+      install_requires=['mongo-connector >= 2.3.0', 'elasticsearch >= 1.2, < 2.0.0'],
+	  extras_require={'aws': ['boto3 >= 1.4.0', 'requests-aws-sign >= 0.1.1']}
       license="Apache License, Version 2.0",
       classifiers=[
           "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 import sys
 
 test_suite = "tests"
-tests_require = ["mongo-orchestration>= 0.2, < 0.4", "requests>=2.5.1"]
+tests_require = ["mongo-orchestration >= 0.2, < 0.4", "requests >= 2.5.1", "boto3 >= 1.4.0", "requests-aws-sign >= 0.1.1"]
 
 if sys.version_info[:2] == (2, 6):
     # Need unittest2 to run unittests in Python 2.6
@@ -30,7 +30,7 @@ setup(name='elastic-doc-manager',
       author_email='mongodb-user@googlegroups.com',
       url='https://github.com/mongodb-labs/elastic-doc-manager',
       packages=["mongo_connector", "mongo_connector.doc_managers"],
-      install_requires=['mongo-connector >= 2.3.0', 'elasticsearch >= 1.2, < 2.0.0'],
+      install_requires=['mongo-connector >= 2.3.0', 'elasticsearch >= 1.2, < 2.0.0', 'boto3 >= 1.4.0', 'requests-aws-sign >= 0.1.1'],
       license="Apache License, Version 2.0",
       classifiers=[
           "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ try:
     from setuptools import setup
 except ImportError:
     from ez_setup import use_setuptools
+
     use_setuptools()
     from setuptools import setup
 import sys
@@ -31,7 +32,7 @@ setup(name='elastic-doc-manager',
       url='https://github.com/mongodb-labs/elastic-doc-manager',
       packages=["mongo_connector", "mongo_connector.doc_managers"],
       install_requires=['mongo-connector >= 2.3.0', 'elasticsearch >= 1.2, < 2.0.0'],
-	  extras_require={'aws': ['boto3 >= 1.4.0', 'requests-aws-sign >= 0.1.1']},
+      extras_require={'aws': ['boto3 >= 1.4.0', 'requests-aws-sign >= 0.1.1']},
       license="Apache License, Version 2.0",
       classifiers=[
           "Development Status :: 4 - Beta",
@@ -51,4 +52,4 @@ setup(name='elastic-doc-manager',
       keywords=['mongo-connector', "mongodb", "elastic", "elasticsearch"],
       test_suite=test_suite,
       tests_require=tests_require
-)
+      )

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='elastic-doc-manager',
       url='https://github.com/mongodb-labs/elastic-doc-manager',
       packages=["mongo_connector", "mongo_connector.doc_managers"],
       install_requires=['mongo-connector >= 2.3.0', 'elasticsearch >= 1.2, < 2.0.0'],
-	  extras_require={'aws': ['boto3 >= 1.4.0', 'requests-aws-sign >= 0.1.1']}
+	  extras_require={'aws': ['boto3 >= 1.4.0', 'requests-aws-sign >= 0.1.1']},
       license="Apache License, Version 2.0",
       classifiers=[
           "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except ImportError:
 import sys
 
 test_suite = "tests"
-tests_require = ["mongo-orchestration >= 0.2, < 0.4", "requests >= 2.5.1", "boto3 >= 1.4.0", "requests-aws-sign >= 0.1.1"]
+tests_require = ["mongo-orchestration >= 0.2, < 0.4", "requests >= 2.5.1"]
 
 if sys.version_info[:2] == (2, 6):
     # Need unittest2 to run unittests in Python 2.6


### PR DESCRIPTION
# Modified from PR #3 by @ReedD

This particular PR is mostly the work of @ReedD with a couple of small variable renames and a slight change to the text of the error that occurs when the `aws` extras were not installed. My original PR #2 worked and was passing, but did not allow for credentials to be loaded from environment variables nor from credentials stored by the AWS CLI configuration at `~/.aws/credentials`.

I will be closing out #2 and will also be remaking this PR for [`elastic2-doc-manager`](https://github.com/mongodb-labs/elastic2-doc-manager) since Amazon now has Elasticsearch 2.3 support launched on July 27th, 2016.

_**Note**_: PR #3 had [successful builds on Python 2.6 but failed builds on all newer versions](https://travis-ci.org/mongodb-labs/elastic-doc-manager/builds/151576930). This seems to have been a hiccup, because I have set up all of the versions of Python used by Travis and used `mongo-orchestration` and Elasticsearch 1.5.2 to run the tests across multiple versions, which pass just fine.
# Original Text from PR #2

This addition allows the definition of connector `args` for `aws` that allow requests to Amazon Elasticsearch Service to be signed.

Documentation on the [mongo-connector Elasticsearch wiki page](https://github.com/mongodb-labs/mongo-connector/wiki/Usage-with-ElasticSearch) will need to be changed to add in instructions for signing after this PR is merged (which I'll be happy to perform).
