### PR TITLE
Fix for travis configuration: upgrade setuptools to be able to instal urllib3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ services:
   - elasticsearch
 
 install:
+  - pip install --upgrade setuptools
   - pip install mongo-orchestration
   - sudo /usr/share/elasticsearch/bin/plugin install elasticsearch/elasticsearch-mapper-attachments/2.4.3
 


### PR DESCRIPTION
Fix from: https://github.com/mongodb-labs/elastic2-doc-manager/pull/21

Fixes this failure: https://travis-ci.org/mongodb-labs/elastic-doc-manager/jobs/160035632#L338-L345
