### PR TITLE
Fix ConfigurationError and make AWS session more configurable

### DIFF
--- a/mongo_connector/doc_managers/elastic_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic_doc_manager.py
@@ -37,8 +37,8 @@ from mongo_connector.doc_managers.formatters import DefaultDocumentFormatter
 
 _HAS_AWS = True
 try:
+    from boto3 import session
     from requests_aws_sign import AWSV4Sign
-    from boto3 import session as aws_session
 except ImportError:
     _HAS_AWS = False
 
@@ -50,6 +50,36 @@ wrap_exceptions = exception_wrapper({
     es_exceptions.RequestError: errors.OperationFailed})
 
 LOG = logging.getLogger(__name__)
+
+DEFAULT_AWS_REGION = 'us-east-1'
+
+
+def convert_aws_args(aws_args):
+    """Convert old style options into arguments to boto3.session.Session."""
+    if not isinstance(aws_args, dict):
+        raise errors.InvalidConfiguration(
+            'Elastic DocManager config option "aws" must be a dict')
+    old_session_kwargs = dict(region='region_name',
+                              access_id='aws_access_key_id',
+                              secret_key='aws_secret_access_key')
+    new_kwargs = {}
+    for arg in aws_args:
+        if arg in old_session_kwargs:
+            new_kwargs[old_session_kwargs[arg]] = aws_args[arg]
+        else:
+            new_kwargs[arg] = aws_args[arg]
+    return new_kwargs
+
+
+def create_aws_auth(aws_args):
+    try:
+        aws_session = session.Session(**convert_aws_args(aws_args))
+    except TypeError as exc:
+        raise errors.InvalidConfiguration(
+            'Elastic DocManager unknown aws config option: %s' % (exc,))
+    return AWSV4Sign(aws_session.get_credentials(),
+                     aws_session.region_name or DEFAULT_AWS_REGION,
+                     'es')
 
 
 class DocManager(DocManagerBase):
@@ -65,23 +95,17 @@ class DocManager(DocManagerBase):
                  attachment_field="content", **kwargs):
         client_options = kwargs.get('clientOptions', {})
         if 'aws' in kwargs:
-            if _HAS_AWS is False:
-                raise ConfigurationError('aws extras must be installed to sign Elasticsearch requests')
-            aws_args = kwargs.get('aws', {'region': 'us-east-1'})
-            aws = aws_session.Session()
-            if 'access_id' in aws_args and 'secret_key' in aws_args:
-                aws = aws_session.Session(
-                    aws_access_key_id = aws_args['access_id'],
-                    aws_secret_access_key = aws_args['secret_key'])
-            credentials = aws.get_credentials()
-            region = aws.region_name or aws_args['region']
-            aws_auth = AWSV4Sign(credentials, region, 'es')
-            client_options['http_auth'] = aws_auth
+            if not _HAS_AWS:
+                raise errors.InvalidConfiguration(
+                    'aws extras must be installed to sign Elasticsearch '
+                    'requests. Install with: '
+                    'pip install elastic-doc-manager[aws]')
+            client_options['http_auth'] = create_aws_auth(kwargs['aws'])
             client_options['use_ssl'] = True
             client_options['verify_certs'] = True
-            client_options['connection_class'] = es_connection.RequestsHttpConnection
-        self.elastic = Elasticsearch(
-            hosts=[url], **client_options)
+            client_options['connection_class'] = \
+                es_connection.RequestsHttpConnection
+        self.elastic = Elasticsearch(hosts=[url], **client_options)
         self.auto_commit_interval = auto_commit_interval
         self.meta_index_name = meta_index_name
         self.meta_type = meta_type

--- a/tests/test_elastic_doc_manager.py
+++ b/tests/test_elastic_doc_manager.py
@@ -19,8 +19,10 @@ import time
 
 sys.path[0:0] = [""]
 
+from mongo_connector import errors
 from mongo_connector.command_helper import CommandHelper
-from mongo_connector.doc_managers.elastic_doc_manager import DocManager
+from mongo_connector.doc_managers.elastic_doc_manager import (
+    DocManager, _HAS_AWS, convert_aws_args, create_aws_auth)
 from mongo_connector.test_utils import MockGridFSFile, TESTARGS
 
 from tests import unittest, elastic_pair
@@ -229,6 +231,40 @@ class TestElasticDocManager(ElasticsearchTestCase):
         self.assertNotIn('test', self._indices())
         self.assertNotIn('test2', self._mappings())
         self.assertNotIn('test3', self._mappings())
+
+
+class TestElasticDocManagerAWS(unittest.TestCase):
+
+    @unittest.skipIf(_HAS_AWS, 'Cannot test with AWS extension installed')
+    def test_aws_raises_invalid_configuration(self):
+        with self.assertRaises(errors.InvalidConfiguration):
+            DocManager('notimportant', aws={})
+
+    def test_convert_aws_args(self):
+        aws_args = dict(region_name='name',
+                        aws_access_key_id='id',
+                        aws_secret_access_key='key',
+                        aws_session_token='token',
+                        profile_name='profile_name')
+        self.assertEqual(convert_aws_args(aws_args), aws_args)
+
+    def test_convert_aws_args_raises_invalid_configuration(self):
+        with self.assertRaises(errors.InvalidConfiguration):
+            convert_aws_args('not_dict')
+
+    def test_convert_aws_args_old_options(self):
+        self.assertEqual(
+            convert_aws_args(dict(region='name',
+                                  access_id='id',
+                                  secret_key='key')),
+            dict(region_name='name',
+                 aws_access_key_id='id',
+                 aws_secret_access_key='key'))
+
+    @unittest.skipUnless(_HAS_AWS, 'Cannot test without AWS extension')
+    def test_create_aws_auth_raises_invalid_configuration(self):
+        with self.assertRaises(errors.InvalidConfiguration):
+            create_aws_auth({'unknown_option': ''})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The aws config option can now contain all the options for boto3.session.Session:
- 'aws_access_key_id'
- 'aws_secret_access_key'
- 'aws_session_token'
- 'region_name'
- 'profile_name'

This is identical to this change in the elastic2-doc-manager: https://github.com/mongodb-labs/elastic2-doc-manager/pull/22
