### PR TITLE
Add support for multiple elastic hosts and HA w/ unit & integration tests

### DIFF
--- a/mongo_connector/doc_managers/elastic_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic_doc_manager.py
@@ -94,6 +94,9 @@ class DocManager(DocManagerBase):
                  meta_index_name="mongodb_meta", meta_type="mongodb_meta",
                  attachment_field="content", **kwargs):
         client_options = kwargs.get('clientOptions', {})
+        client_options.setdefault('sniff_on_start', True)
+        client_options.setdefault('sniff_on_connection_fail', True)
+        client_options.setdefault('sniffer_timeout', 60)
         if 'aws' in kwargs:
             if not _HAS_AWS:
                 raise errors.InvalidConfiguration(
@@ -105,7 +108,9 @@ class DocManager(DocManagerBase):
             client_options['verify_certs'] = True
             client_options['connection_class'] = \
                 es_connection.RequestsHttpConnection
-        self.elastic = Elasticsearch(hosts=[url], **client_options)
+        if type(url) is not list:
+            url = [url]
+        self.elastic = Elasticsearch(hosts=url, **client_options)
         self.auto_commit_interval = auto_commit_interval
         self.meta_index_name = meta_index_name
         self.meta_type = meta_type

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -29,3 +29,5 @@ else:
 elastic_host = unicode(os.environ.get("ES_HOST", 'localhost'))
 elastic_port = unicode(os.environ.get("ES_PORT", 9200))
 elastic_pair = '%s:%s' % (elastic_host, elastic_port)
+elastic_nodes = [elastic_pair, '%s:%s' % (elastic_host,
+                                          unicode(int(elastic_port)+1))]

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -31,7 +31,7 @@ from mongo_connector.test_utils import (ReplicaSet,
                                         close_client)
 
 from mongo_connector.util import retry_until_ok
-from tests import unittest, elastic_pair
+from tests import unittest, elastic_pair, elastic_nodes
 
 
 class ElasticsearchTestCase(unittest.TestCase):
@@ -272,6 +272,15 @@ class TestElastic(ElasticsearchTestCase):
             self.assertNotIn('inf', doc)
             self.assertNotIn('nan', doc)
             self.assertTrue(doc['still_exists'])
+
+
+class TestElasticMultipleHosts(unittest.TestCase):
+    """Integration tests for mongo-connector + Elasticsearch Cluster."""
+
+    def test_multiple_hosts(self):
+        elastic_doc = DocManager(elastic_nodes)
+        self.assertEqual(len(elastic_doc.elastic.transport.hosts), 2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
sniff\* options default so they can be overridden in config file.

Taken from https://github.com/mongodb-labs/elastic2-doc-manager/pull/17.
