### PR TITLE
Add buffering of insert, update, and remove operations

### DIFF
--- a/mongo_connector/doc_managers/elastic_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic_doc_manager.py
@@ -19,13 +19,14 @@ Elasticsearch.
 """
 import base64
 import logging
+import warnings
 
-from threading import Timer
+from threading import Timer, Lock
 
 import bson.json_util
 
 from elasticsearch import Elasticsearch, exceptions as es_exceptions, connection as es_connection
-from elasticsearch.helpers import scan, streaming_bulk, BulkIndexError
+from elasticsearch.helpers import bulk, scan, streaming_bulk, BulkIndexError
 
 from mongo_connector import errors
 from mongo_connector.compat import u
@@ -111,6 +112,17 @@ class DocManager(DocManagerBase):
         if type(url) is not list:
             url = [url]
         self.elastic = Elasticsearch(hosts=url, **client_options)
+
+        self._formatter = DefaultDocumentFormatter()
+        self.BulkBuffer = BulkBuffer(self)
+
+        # As bulk operation can be done in another thread
+        # lock is needed to prevent access to BulkBuffer
+        # while commiting documents to Elasticsearch
+        # It is because BulkBuffer might get outdated
+        # docs from Elasticsearch if bulk is still ongoing
+        self.lock = Lock()
+
         self.auto_commit_interval = auto_commit_interval
         self.meta_index_name = meta_index_name
         self.meta_type = meta_type
@@ -118,7 +130,6 @@ class DocManager(DocManagerBase):
         self.chunk_size = chunk_size
         if self.auto_commit_interval not in [None, 0]:
             self.run_auto_commit()
-        self._formatter = DefaultDocumentFormatter()
 
         self.has_attachment_mapping = False
         self.attachment_field = attachment_field
@@ -130,7 +141,9 @@ class DocManager(DocManagerBase):
 
     def stop(self):
         """Stop the auto-commit thread."""
-        self.auto_commit_interval = None
+        self.auto_commit_interval = 0
+        # Commit docs from buffer
+        self.commit()
 
     def apply_update(self, doc, update_spec):
         if "$set" not in update_spec and "$unset" not in update_spec:
@@ -140,6 +153,8 @@ class DocManager(DocManagerBase):
 
     @wrap_exceptions
     def handle_command(self, doc, namespace, timestamp):
+        # Flush buffer before handle command
+        self.commit()
         db = namespace.split('.', 1)[0]
         if doc.get('dropDatabase'):
             dbs = self.command_helper.map_db(db)
@@ -170,35 +185,59 @@ class DocManager(DocManagerBase):
         """Apply updates given in update_spec to the document whose id
         matches that of doc.
         """
-        self.commit()
+
         index, doc_type = self._index_and_mapping(namespace)
-        document = self.elastic.get(index=index, doc_type=doc_type,
-                                    id=u(document_id))
-        updated = self.apply_update(document['_source'], update_spec)
-        # _id is immutable in MongoDB, so won't have changed in update
-        updated['_id'] = document['_id']
-        self.upsert(updated, namespace, timestamp)
+        with self.lock:
+            # Check if document source is stored in local buffer
+            document = self.BulkBuffer.get_from_sources(index,
+                                                        doc_type,
+                                                        u(document_id))
+        if document:
+            # Document source collected from local buffer
+            # Perform apply_update on it and then it will be
+            # ready for commiting to Elasticsearch
+            updated = self.apply_update(document, update_spec)
+            # _id is immutable in MongoDB, so won't have changed in update
+            updated['_id'] = document_id
+            self.upsert(updated, namespace, timestamp)
+        else:
+            # Document source needs to be retrieved from Elasticsearch
+            # before performing update. Pass update_spec to upsert function
+            updated = {"_id": document_id}
+            self.upsert(updated, namespace, timestamp, update_spec)
         # upsert() strips metadata, so only _id + fields in _source still here
         return updated
 
     @wrap_exceptions
-    def upsert(self, doc, namespace, timestamp):
+    def upsert(self, doc, namespace, timestamp, update_spec=None):
         """Insert a document into Elasticsearch."""
         index, doc_type = self._index_and_mapping(namespace)
         # No need to duplicate '_id' in source document
         doc_id = u(doc.pop("_id"))
         metadata = {
-            "ns": namespace,
-            "_ts": timestamp
+            'ns': namespace,
+            '_ts': timestamp
         }
+
         # Index the source document, using lowercase namespace as index name.
-        self.elastic.index(index=index, doc_type=doc_type,
-                           body=self._formatter.format_document(doc), id=doc_id,
-                           refresh=(self.auto_commit_interval == 0))
+        action = {
+            '_op_type': 'index',
+            '_index': index,
+            '_type': doc_type,
+            '_id': doc_id,
+            '_source': self._formatter.format_document(doc)
+        }
         # Index document metadata with original namespace (mixed upper/lower).
-        self.elastic.index(index=self.meta_index_name, doc_type=self.meta_type,
-                           body=bson.json_util.dumps(metadata), id=doc_id,
-                           refresh=(self.auto_commit_interval == 0))
+        meta_action = {
+            '_op_type': 'index',
+            '_index': self.meta_index_name,
+            '_type': self.meta_type,
+            '_id': doc_id,
+            '_source': bson.json_util.dumps(metadata)
+        }
+
+        self.index(action, meta_action, doc, update_spec)
+
         # Leave _id, since it's part of the original document
         doc['_id'] = doc_id
 
@@ -212,18 +251,18 @@ class DocManager(DocManagerBase):
                 index, doc_type = self._index_and_mapping(namespace)
                 doc_id = u(doc.pop("_id"))
                 document_action = {
-                    "_index": index,
-                    "_type": doc_type,
-                    "_id": doc_id,
-                    "_source": self._formatter.format_document(doc)
+                    '_index': index,
+                    '_type': doc_type,
+                    '_id': doc_id,
+                    '_source': self._formatter.format_document(doc)
                 }
                 document_meta = {
-                    "_index": self.meta_index_name,
-                    "_type": self.meta_type,
-                    "_id": doc_id,
-                    "_source": {
-                        "ns": namespace,
-                        "_ts": timestamp
+                    '_index': self.meta_index_name,
+                    '_type': self.meta_type,
+                    '_id': doc_id,
+                    '_source': {
+                        'ns': namespace,
+                        '_ts': timestamp
                     }
                 }
                 yield document_action
@@ -279,23 +318,43 @@ class DocManager(DocManagerBase):
         doc = self._formatter.format_document(doc)
         doc[self.attachment_field] = base64.b64encode(f.read()).decode()
 
-        self.elastic.index(index=index, doc_type=doc_type,
-                           body=doc, id=doc_id,
-                           refresh=(self.auto_commit_interval == 0))
-        self.elastic.index(index=self.meta_index_name, doc_type=self.meta_type,
-                           body=bson.json_util.dumps(metadata), id=doc_id,
-                           refresh=(self.auto_commit_interval == 0))
+        action = {
+            '_op_type': 'index',
+            '_index': index,
+            '_type': doc_type,
+            '_id': doc_id,
+            '_source': doc
+        }
+        meta_action = {
+            '_op_type': 'index',
+            '_index': self.meta_index_name,
+            '_type': self.meta_type,
+            '_id': doc_id,
+            '_source': bson.json_util.dumps(metadata)
+        }
+
+        self.index(action, meta_action)
 
     @wrap_exceptions
     def remove(self, document_id, namespace, timestamp):
         """Remove a document from Elasticsearch."""
         index, doc_type = self._index_and_mapping(namespace)
-        self.elastic.delete(index=index, doc_type=doc_type,
-                            id=u(document_id),
-                            refresh=(self.auto_commit_interval == 0))
-        self.elastic.delete(index=self.meta_index_name, doc_type=self.meta_type,
-                            id=u(document_id),
-                            refresh=(self.auto_commit_interval == 0))
+
+        action = {
+            '_op_type': 'delete',
+            '_index': index,
+            '_type': doc_type,
+            '_id': u(document_id)
+        }
+
+        meta_action = {
+            '_op_type': 'delete',
+            '_index': self.meta_index_name,
+            '_type': self.meta_type,
+            '_id': u(document_id)
+        }
+
+        self.index(action, meta_action)
 
     @wrap_exceptions
     def _stream_search(self, *args, **kwargs):
@@ -325,13 +384,33 @@ class DocManager(DocManagerBase):
                 }
             })
 
+    def index(self, action, meta_action, doc_source=None, update_spec=None):
+        with self.lock:
+            self.BulkBuffer.add_upsert(action, meta_action, doc_source, update_spec)
+
+        # Divide by two to account for meta actions
+        if len(self.BulkBuffer.action_buffer) / 2 >= self.chunk_size or self.auto_commit_interval == 0:
+            self.commit()
+
     def commit(self):
-        """Refresh all Elasticsearch indexes."""
+        """Send bulk requests and clear buffer"""
+        with self.lock:
+            try:
+                action_buffer = self.BulkBuffer.get_buffer()
+                if action_buffer:
+                    successes, errors = bulk(self.elastic, action_buffer)
+                    LOG.debug("Bulk successfully done for %d docs" % successes)
+                    if errors:
+                        LOG.error("Error occurred during bulk to ElasticSearch:"
+                                  " %r" % errors)
+            except es_exceptions.ElasticsearchException:
+                LOG.exception("Exception while commiting to Elasticsearch")
+
         retry_until_ok(self.elastic.indices.refresh, index="")
 
     def run_auto_commit(self):
         """Periodically commit to the Elastic server."""
-        self.elastic.indices.refresh()
+        self.commit()
         if self.auto_commit_interval not in [None, 0]:
             Timer(self.auto_commit_interval, self.run_auto_commit).start()
 
@@ -357,3 +436,181 @@ class DocManager(DocManagerBase):
         except es_exceptions.RequestError:
             # no documents so ES returns 400 because of undefined _ts mapping
             return None
+
+
+class BulkBuffer(object):
+
+    def __init__(self, docman):
+
+        # Parent object
+        self.docman = docman
+
+        # Action buffer for bulk indexing
+        self.action_buffer = []
+
+        # Docs to update
+        # Dict stores all documents for which firstly
+        # source has to be retrieved from Elasticsearch
+        # and then apply_update needs to be performed
+        # Format: [ (doc, update_spec, action_buffer_index, get_from_ES) ]
+        self.doc_to_update = []
+
+        # Below dictionary contains ids of documents
+        # which need to be retrieved from Elasticsearch
+        # It prevents from getting same document multiple times from ES
+        # Format: {"_index": {"_type": {"_id": True}}}
+        self.doc_to_get = {}
+
+        # Dictionary of sources
+        # Format: {"_index": {"_type": {"_id": {"_source": actual_source}}}}
+        self.sources = {}
+
+    def add_upsert(self, action, meta_action, doc_source, update_spec):
+        """
+        Function which stores sources for "insert" actions
+        and decide if for "update" action has to add docs to
+        get source buffer
+        """
+
+        # Whenever update_spec is provided to this method
+        # it means that doc source needs to be retrieved
+        # from Elasticsearch. It means also that source
+        # is not stored in local buffer
+        if update_spec:
+            self.bulk_index(action, meta_action)
+
+            # -1 -> to get latest index number
+            # -1 -> to get action instead of meta_action
+            # Update document based on source retrieved from ES
+            self.add_doc_to_update(action, update_spec, len(self.action_buffer) - 2)
+        else:
+            # Insert and update operations provide source
+            # Store it in local buffer and use for comming updates
+            # inside same buffer
+            # add_to_sources will not be called for delete operation
+            # as it does not provide doc_source
+            if doc_source:
+                self.add_to_sources(action, doc_source)
+            self.bulk_index(action, meta_action)
+
+    def add_doc_to_update(self, action, update_spec, action_buffer_index):
+        """
+        Prepare document for update based on Elasticsearch response.
+        Set flag if document needs to be retrieved from Elasticsearch
+        """
+
+        doc = {'_index': action['_index'],
+               '_type': action['_type'],
+               '_id': action['_id']}
+
+        # If get_from_ES == True -> get document's source from Elasticsearch
+        get_from_ES = self.should_get_id(action)
+        self.doc_to_update.append((doc, update_spec, action_buffer_index, get_from_ES))
+
+    def should_get_id(self, action):
+        """
+        Mark document to retrieve its source from Elasticsearch.
+        Returns:
+            True - if marking document for the first time in this bulk
+            False - if document has been already marked
+        """
+        mapping_ids = self.doc_to_get.setdefault(
+            action['_index'], {}).setdefault(action['_type'], set())
+        if action['_id'] in mapping_ids:
+            # There is an update on this id already
+            return False
+        else:
+            mapping_ids.add(action['_id'])
+            return True
+
+    def get_docs_sources_from_ES(self):
+        """Get document sources using MGET elasticsearch API"""
+        docs = [doc for doc, _, _, get_from_ES in self.doc_to_update if get_from_ES]
+        if docs:
+            documents = self.docman.elastic.mget(body={'docs': docs}, realtime=True)
+            return iter(documents['docs'])
+        else:
+            return iter([])
+
+    @wrap_exceptions
+    def update_sources(self):
+        """Update local sources based on response from Elasticsearch"""
+        ES_documents = self.get_docs_sources_from_ES()
+
+        for doc, update_spec, action_buffer_index, get_from_ES in self.doc_to_update:
+            if get_from_ES:
+                # Update source based on response from ES
+                ES_doc = next(ES_documents)
+                if ES_doc['found']:
+                    source = ES_doc['_source']
+                else:
+                    # Document not found in elasticsearch,
+                    # Seems like something went wrong during replication
+                    LOG.error("mGET: Document id: %s has not been found "
+                              "in Elasticsearch. Due to that "
+                              "following update failed: %s", doc['_id'], update_spec)
+                    self.reset_action(action_buffer_index)
+                    continue
+            else:
+                # Get source stored locally before applying update
+                # as it is up-to-date
+                source = self.get_from_sources(doc['_index'],
+                                               doc['_type'],
+                                               doc['_id'])
+                if not source:
+                    LOG.error("mGET: Document id: %s has not been found "
+                              "in local sources. Due to that following "
+                              "update failed: %s", doc["_id"], update_spec)
+                    self.reset_action(action_buffer_index)
+                    continue
+
+            updated = self.docman.apply_update(source, update_spec)
+
+            # Remove _id field from source
+            if '_id' in updated:
+                del updated['_id']
+
+            # Everytime update locally stored sources to keep them up-to-date
+            self.add_to_sources(doc, updated)
+
+            self.action_buffer[action_buffer_index]['_source'] = self.docman._formatter.format_document(updated)
+
+        # Remove empty actions if there were errors
+        self.action_buffer = [each_action for each_action in self.action_buffer if each_action]
+
+    def reset_action(self, action_buffer_index):
+        """Reset specific action as update failed"""
+        self.action_buffer[action_buffer_index] = {}
+        self.action_buffer[action_buffer_index + 1] = {}
+
+    def add_to_sources(self, action, doc_source):
+        """Store sources locally"""
+        mapping = self.sources.setdefault(action['_index'], {}).setdefault(action['_type'], {})
+        mapping[action['_id']] = doc_source
+
+    def get_from_sources(self, index, doc_type, document_id):
+        """Get source stored locally"""
+        return self.sources.get(index, {}).get(doc_type, {}).get(document_id, {})
+
+    def bulk_index(self, action, meta_action):
+        self.action_buffer.append(action)
+        self.action_buffer.append(meta_action)
+
+    def clean_up(self):
+        """Do clean-up before returning buffer"""
+        self.action_buffer = []
+        self.sources = {}
+        self.doc_to_get = {}
+        self.doc_to_update = []
+
+    def get_buffer(self):
+        """Get buffer which needs to be bulked to elasticsearch"""
+
+        # Get sources for documents which are in Elasticsearch
+        # and they are not in local buffer
+        if self.doc_to_update:
+            self.update_sources()
+
+        ES_buffer = self.action_buffer
+        self.clean_up()
+        return ES_buffer

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -20,12 +20,13 @@ import time
 
 from bson import SON
 from elasticsearch import Elasticsearch
+from elasticsearch.helpers import bulk, scan
 from gridfs import GridFS
 
 sys.path[0:0] = [""]
 
-from mongo_connector.doc_managers.elastic_doc_manager import DocManager
 from mongo_connector.connector import Connector
+from mongo_connector.doc_managers.elastic_doc_manager import DocManager
 from mongo_connector.test_utils import (ReplicaSet,
                                         assert_soon,
                                         close_client)
@@ -106,7 +107,8 @@ class TestElastic(ElasticsearchTestCase):
             os.unlink("oplog.timestamp")
         except OSError:
             pass
-        docman = DocManager(elastic_pair)
+        docman = DocManager(elastic_pair,
+                            auto_commit_interval=0)
         self.connector = Connector(
             mongo_address=self.repl_set.uri,
             ns_set=['test.test'],

--- a/tests/test_elastic_doc_manager.py
+++ b/tests/test_elastic_doc_manager.py
@@ -24,22 +24,31 @@ from mongo_connector.command_helper import CommandHelper
 from mongo_connector.doc_managers.elastic_doc_manager import (
     DocManager, _HAS_AWS, convert_aws_args, create_aws_auth)
 from mongo_connector.test_utils import MockGridFSFile, TESTARGS
+from mongo_connector.util import retry_until_ok
 
 from tests import unittest, elastic_pair
 from tests.test_elastic import ElasticsearchTestCase
+from elasticsearch.helpers import bulk
 
 
 class TestElasticDocManager(ElasticsearchTestCase):
     """Unit tests for the Elastic DocManager."""
 
     def test_update(self):
-        """Test the update method."""
+        """Test the update method using locally stored source"""
+
+        # If testing with BulkBuffer, auto_commit_interval
+        # needs to be None to not clear locally stored sources
+        self.elastic_doc.auto_commit_interval = None
+
         doc_id = 1
         doc = {"_id": doc_id, "a": 1, "b": 2}
         self.elastic_doc.upsert(doc, *TESTARGS)
+
         # $set only
         update_spec = {"$set": {"a": 1, "b": 2}}
         doc = self.elastic_doc.update(doc_id, update_spec, *TESTARGS)
+
         self.assertEqual(doc, {"_id": '1', "a": 1, "b": 2})
         # $unset only
         update_spec = {"$unset": {"a": True}}
@@ -49,6 +58,15 @@ class TestElasticDocManager(ElasticsearchTestCase):
         update_spec = {"$unset": {"b": True}, "$set": {"c": 3}}
         doc = self.elastic_doc.update(doc_id, update_spec, *TESTARGS)
         self.assertEqual(doc, {"_id": '1', "c": 3})
+
+        # Commit doc to Elasticsearch and get it from there
+        # to test if BulkBuffer works fine
+        self.elastic_doc.commit()
+        res = self._search()
+        self.assertEqual(doc, next(res))
+
+        # set auto_commit_interval back to 0
+        self.elastic_doc.auto_commit_interval = 0
 
     def test_upsert(self):
         """Test the upsert method."""
@@ -61,6 +79,82 @@ class TestElasticDocManager(ElasticsearchTestCase):
         for doc in res:
             self.assertEqual(doc['_id'], '1')
             self.assertEqual(doc['_source']['name'], 'John')
+
+    def test_update_using_ES(self):
+        """
+        Test the update method and getting sources for update
+        for Elasticsearch
+        """
+
+        # If testing with BulkBuffer, auto_commit_interval
+        # needs to be None to not clear locally stored sources
+        self.elastic_doc.auto_commit_interval = None
+
+        doc_id = 1
+        doc = {"_id": doc_id, "a": 1, "b": 2}
+        self.elastic_doc.upsert(doc, *TESTARGS)
+        self.elastic_doc.commit()
+
+        update_spec = {"$set": {"a": 1, "b": 2}}
+        self.elastic_doc.update(doc_id, update_spec, *TESTARGS)
+
+        update_spec = {"$set": {"a": 10, "b": 20}}
+        self.elastic_doc.update(doc_id, update_spec, *TESTARGS)
+
+        update_spec = {"$set": {"a": 100, "b": 200}}
+        self.elastic_doc.update(doc_id, update_spec, *TESTARGS)
+
+        # Commit doc to Elasticsearch and get it from there
+        # to test if BulkBuffer works fine
+        doc["a"] = 100
+        doc["b"] = 200
+        self.elastic_doc.commit()
+        res = self._search()
+        self.assertEqual(doc, next(res))
+
+        # set auto_commit_interval back to 0
+        self.elastic_doc.auto_commit_interval = 0
+
+    def test_upsert(self):
+        """Test the upsert method."""
+        docc = {'_id': '1', 'name': 'John'}
+        self.elastic_doc.upsert(docc, *TESTARGS)
+        res = self.elastic_conn.search(
+            index="test", doc_type='test',
+            body={"query": {"match_all": {}}}
+        )["hits"]["hits"]
+        for doc in res:
+            self.assertEqual(doc['_id'], '1')
+            self.assertEqual(doc['_source']['name'], 'John')
+
+    def test_upsert_with_updates(self):
+        """Test the upsert method with multi updates
+        and clearing buffer (commit) after each update."""
+
+        doc_id = 1
+        docc = {'_id': doc_id, 'name': 'John'}
+        self.elastic_doc.upsert(docc, *TESTARGS)
+
+        update_spec = {'$set': {'a': 1, 'b': 2}}
+        self.elastic_doc.update(doc_id, update_spec, *TESTARGS)
+
+        update_spec = {'$set': {'a': 2, 'b': 3, 'c': ['test']}}
+        self.elastic_doc.update(doc_id, update_spec, *TESTARGS)
+
+        update_spec = {'$set': {'c': ['test', 'test2']}}
+        self.elastic_doc.update(doc_id, update_spec, *TESTARGS)
+
+        res = self.elastic_conn.search(
+            index="test", doc_type='test',
+            body={"query": {"match_all": {}}}
+        )["hits"]["hits"]
+
+        for doc in res:
+            self.assertEqual(doc['_id'], '1')
+            self.assertEqual(doc['_source']['name'], 'John')
+            self.assertEqual(doc['_source']['a'], 2)
+            self.assertEqual(doc['_source']['b'], 3)
+            self.assertEqual(doc['_source']['c'], ["test", "test2"])
 
     def test_bulk_upsert(self):
         """Test the bulk_upsert method."""
@@ -75,14 +169,14 @@ class TestElasticDocManager(ElasticsearchTestCase):
         for i, r in enumerate(returned_ids):
             self.assertEqual(r, i)
 
-        docs = ({"_id": i, "weight": 2*i} for i in range(1000))
+        docs = ({"_id": i, "weight": 2 * i} for i in range(1000))
         self.elastic_doc.bulk_upsert(docs, *TESTARGS)
 
         returned_ids = sorted(
             int(doc["weight"]) for doc in self._search())
         self.assertEqual(len(returned_ids), 1000)
         for i, r in enumerate(returned_ids):
-            self.assertEqual(r, 2*i)
+            self.assertEqual(r, 2 * i)
 
     def test_remove(self):
         """Test the remove method."""
@@ -163,13 +257,18 @@ class TestElasticDocManager(ElasticsearchTestCase):
     def test_elastic_commit(self):
         """Test the auto_commit_interval attribute."""
         docc = {'_id': '3', 'name': 'Waldo'}
-        docman = DocManager(elastic_pair)
+
+        # Disable 1s refresh in elasticsearch
+        # https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html
+        disable_refresh_body = {'index': {'refresh_interval': '-1'}}
+        self.elastic_conn.indices.put_settings(index='test', body=disable_refresh_body)
+
         # test cases:
         # -1 = no autocommit
         # 0 = commit immediately
         # x > 0 = commit within x seconds
         for autocommit_interval in [None, 0, 1, 2]:
-            docman.auto_commit_interval = autocommit_interval
+            docman = DocManager(elastic_pair, auto_commit_interval=autocommit_interval)
             docman.upsert(docc, *TESTARGS)
             if autocommit_interval is None:
                 docman.commit()
@@ -182,8 +281,11 @@ class TestElasticDocManager(ElasticsearchTestCase):
                              "auto_commit_interval = %s" % str(
                                  autocommit_interval))
             self.assertEqual(results[0]["name"], "Waldo")
+            docman.stop()
             self._remove()
-        docman.stop()
+            retry_until_ok(self.elastic_conn.indices.refresh, index="")
+        enable_refresh_body = {"index": {"refresh_interval": "1s"}}
+        self.elastic_conn.indices.put_settings(index="test", body=enable_refresh_body)
 
     def test_get_last_doc(self):
         """Test the get_last_doc method.
@@ -216,21 +318,86 @@ class TestElasticDocManager(ElasticsearchTestCase):
         self.elastic_doc.command_helper = CommandHelper()
 
         self.elastic_doc.handle_command({'create': 'test2'}, *cmd_args)
-        time.sleep(1)
+        retry_until_ok(self.elastic_conn.indices.refresh, index="")
         self.assertIn('test2', self._mappings('test'))
 
+        docs = [
+            {"_id": 0, "name": "ted"},
+            {"_id": 1, "name": "marsha"},
+            {"_id": 2, "name": "nikolas"}
+        ]
+        self.elastic_doc.upsert(docs[0], 'test.test2', 1)
+        self.elastic_doc.upsert(docs[1], 'test.test2', 1)
+        self.elastic_doc.upsert(docs[2], 'test.test2', 1)
+
+        # Commit upserted docs as they are in buffer
+        self.elastic_doc.commit()
+
+        res = list(self.elastic_doc._stream_search(
+            index="test", doc_type='test2',
+            body={"query": {"match_all": {}}}
+        ))
+        for d in docs:
+            self.assertTrue(d in res)
+
         self.elastic_doc.handle_command({'drop': 'test2'}, *cmd_args)
-        time.sleep(1)
-        self.assertNotIn('test2', self._mappings('test'))
+        retry_until_ok(self.elastic_conn.indices.refresh, index="")
+        res = list(self.elastic_doc._stream_search(
+            index="test", doc_type='test2',
+            body={"query": {"match_all": {}}})
+        )
+        self.assertEqual(0, len(res))
 
         self.elastic_doc.handle_command({'create': 'test2'}, *cmd_args)
         self.elastic_doc.handle_command({'create': 'test3'}, *cmd_args)
-        time.sleep(1)
+        retry_until_ok(self.elastic_conn.indices.refresh, index="")
         self.elastic_doc.handle_command({'dropDatabase': 1}, *cmd_args)
-        time.sleep(1)
+        retry_until_ok(self.elastic_conn.indices.refresh, index="")
         self.assertNotIn('test', self._indices())
         self.assertNotIn('test2', self._mappings())
         self.assertNotIn('test3', self._mappings())
+
+    def buffer_and_drop(self):
+        """Insert document and drop collection while doc is in buffer"""
+
+        self.elastic_doc.command_helper = CommandHelper()
+
+        self.elastic_doc.auto_commit_interval = None
+        index = "test3"
+        doc_type = "foo"
+        cmd_args = ('%s.%s' % (index, doc_type), 1)
+
+        doc_id = 1
+        doc = {"_id": doc_id, "name": "bar"}
+        self.elastic_doc.upsert(doc, *cmd_args)
+
+        self.elastic_doc.handle_command({'drop': doc_type}, *cmd_args)
+        retry_until_ok(self.elastic_conn.indices.refresh, index="")
+
+        # Commit should be called before command has been handled
+        # Which means that buffer should be empty
+        self.assertFalse(self.elastic_doc.BulkBuffer.get_buffer())
+
+        # After drop, below search should return no results
+        res = list(self.elastic_doc._stream_search(
+            index=index, doc_type=doc_type,
+            body={"query": {"match_all": {}}})
+        )
+        self.assertFalse(res)
+
+        # Test dropDatabase as well
+        # Firstly add document to database again
+        # This time update doc as well
+        self.elastic_doc.upsert(doc, *cmd_args)
+        update_spec = {"$set": {"name": "foo2"}}
+        self.elastic_doc.update(doc_id, update_spec, *cmd_args)
+        self.elastic_doc.handle_command({'dropDatabase': 1}, *cmd_args)
+        retry_until_ok(self.elastic_conn.indices.refresh, index="")
+        self.assertFalse(self.elastic_doc.BulkBuffer.get_buffer())
+        self.assertNotIn(index, self._mappings())
+
+        # set auto_commit_interval back to 0
+        self.elastic_doc.auto_commit_interval = 0
 
 
 class TestElasticDocManagerAWS(unittest.TestCase):


### PR DESCRIPTION
The DocManager now buffers operations and periodically sends these to
Elasticsearch as a single bulk operation.
The bulk commit interval is set via the auto_commit_interval parameter and
the bulk commit size is set via the chunk_size parameter.

This is a copy of this change for the elastic2-doc-manager: https://github.com/mongodb-labs/elastic2-doc-manager/pull/15 