### PR TITLE
Do not automatically add sniff_* options

### DIFF
--- a/mongo_connector/doc_managers/elastic_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic_doc_manager.py
@@ -94,9 +94,6 @@ class DocManager(DocManagerBase):
                  meta_index_name="mongodb_meta", meta_type="mongodb_meta",
                  attachment_field="content", **kwargs):
         client_options = kwargs.get('clientOptions', {})
-        client_options.setdefault('sniff_on_start', True)
-        client_options.setdefault('sniff_on_connection_fail', True)
-        client_options.setdefault('sniffer_timeout', 60)
         if 'aws' in kwargs:
             if not _HAS_AWS:
                 raise errors.InvalidConfiguration(


### PR DESCRIPTION
This is a backport of this change https://github.com/mongodb-labs/elastic2-doc-manager/pull/27