### PR TITLE
Add DocManager __version__

### DIFF
--- a/mongo_connector/doc_managers/elastic_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic_doc_manager.py
@@ -53,6 +53,9 @@ LOG = logging.getLogger(__name__)
 
 DEFAULT_AWS_REGION = 'us-east-1'
 
+__version__ = '0.2.1.dev0'
+"""Elasticsearch 1.X DocManager version."""
+
 
 def convert_aws_args(aws_args):
     """Convert old style options into arguments to boto3.session.Session."""


### PR DESCRIPTION
mongo-connector 2.5.0 will log the __version__ at startup. Introduced here: mongodb-labs/mongo-connector#575