### PR TITLE
Automatically flush the operation buffer every 5 seconds

### DIFF
--- a/mongo_connector/doc_managers/elastic_doc_manager.py
+++ b/mongo_connector/doc_managers/elastic_doc_manager.py
@@ -19,9 +19,9 @@ Elasticsearch.
 """
 import base64
 import logging
+import threading
+import time
 import warnings
-
-from threading import Timer, Lock
 
 import bson.json_util
 
@@ -51,6 +51,9 @@ wrap_exceptions = exception_wrapper({
     es_exceptions.RequestError: errors.OperationFailed})
 
 LOG = logging.getLogger(__name__)
+
+DEFAULT_SEND_INTERVAL = 5
+"""The default interval in seconds to send buffered operations."""
 
 DEFAULT_AWS_REGION = 'us-east-1'
 
@@ -84,6 +87,59 @@ def create_aws_auth(aws_args):
     return AWSV4Sign(aws_session.get_credentials(),
                      aws_session.region_name or DEFAULT_AWS_REGION,
                      'es')
+
+
+class AutoCommiter(threading.Thread):
+    """Thread that periodically sends buffered operations to Elastic.
+
+    :Parameters:
+      - `docman`: The Elasticsearch DocManager.
+      - `send_interval`: Number of seconds to wait before sending buffered
+        operations to Elasticsearch. Set to None or 0 to disable.
+      - `commit_interval`: Number of seconds to wait before committing
+        buffered operations to Elasticsearch. Set to None or 0 to disable.
+      - `sleep_interval`: Number of seconds to sleep.
+    """
+    def __init__(self, docman, send_interval, commit_interval,
+                 sleep_interval=1):
+        super(AutoCommiter, self).__init__()
+        self._docman = docman
+        # Change `None` intervals to 0
+        self._send_interval = send_interval if send_interval else 0
+        self._commit_interval = commit_interval if commit_interval else 0
+        self._should_auto_send = self._send_interval > 0
+        self._should_auto_commit = self._commit_interval > 0
+        self._sleep_interval = max(sleep_interval, 1)
+        self._stopped = False
+        self.daemon = True
+
+    def join(self, timeout=None):
+        self._stopped = True
+        super(AutoCommiter, self).join(timeout=timeout)
+
+    def run(self):
+        """Periodically sends buffered operations and/or commit.
+        """
+        if not self._should_auto_commit and not self._should_auto_send:
+            return
+        last_send, last_commit = 0, 0
+        while not self._stopped:
+            if self._should_auto_commit:
+                if last_commit > self._commit_interval:
+                    self._docman.commit()
+                    # commit also sends so reset both
+                    last_send, last_commit = 0, 0
+                    # Give a chance to exit the loop
+                    if self._stopped:
+                        break
+
+            if self._should_auto_send:
+                if last_send > self._send_interval:
+                    self._docman.send_buffered_operations()
+                    last_send = 0
+            time.sleep(self._sleep_interval)
+            last_send += self._sleep_interval
+            last_commit += self._sleep_interval
 
 
 class DocManager(DocManagerBase):
@@ -121,18 +177,20 @@ class DocManager(DocManagerBase):
         # while commiting documents to Elasticsearch
         # It is because BulkBuffer might get outdated
         # docs from Elasticsearch if bulk is still ongoing
-        self.lock = Lock()
+        self.lock = threading.Lock()
 
         self.auto_commit_interval = auto_commit_interval
+        self.auto_send_interval = kwargs.get('autoSendInterval',
+                                             DEFAULT_SEND_INTERVAL)
         self.meta_index_name = meta_index_name
         self.meta_type = meta_type
         self.unique_key = unique_key
         self.chunk_size = chunk_size
-        if self.auto_commit_interval not in [None, 0]:
-            self.run_auto_commit()
-
         self.has_attachment_mapping = False
         self.attachment_field = attachment_field
+        self.auto_commiter = AutoCommiter(self, self.auto_send_interval,
+                                          self.auto_commit_interval)
+        self.auto_commiter.start()
 
     def _index_and_mapping(self, namespace):
         """Helper method for getting the index and type from a namespace."""
@@ -141,8 +199,9 @@ class DocManager(DocManagerBase):
 
     def stop(self):
         """Stop the auto-commit thread."""
+        self.auto_commiter.join()
         self.auto_commit_interval = 0
-        # Commit docs from buffer
+        # Commit any remaining docs from buffer
         self.commit()
 
     def apply_update(self, doc, update_spec):
@@ -392,27 +451,28 @@ class DocManager(DocManagerBase):
         if len(self.BulkBuffer.action_buffer) / 2 >= self.chunk_size or self.auto_commit_interval == 0:
             self.commit()
 
-    def commit(self):
-        """Send bulk requests and clear buffer"""
+    def send_buffered_operations(self):
+        """Send buffered operations to Elasticsearch.
+
+        This method is periodically called by the AutoCommitThread.
+        """
         with self.lock:
             try:
                 action_buffer = self.BulkBuffer.get_buffer()
                 if action_buffer:
                     successes, errors = bulk(self.elastic, action_buffer)
-                    LOG.debug("Bulk successfully done for %d docs" % successes)
+                    LOG.debug("Bulk request finished, successfully sent %d "
+                              "operations", successes)
                     if errors:
-                        LOG.error("Error occurred during bulk to ElasticSearch:"
-                                  " %r" % errors)
+                        LOG.error(
+                            "Bulk request finished with errors: %r", errors)
             except es_exceptions.ElasticsearchException:
-                LOG.exception("Exception while commiting to Elasticsearch")
+                LOG.exception("Bulk request failed with exception")
 
+    def commit(self):
+        """Send buffered requests and refresh all indexes."""
+        self.send_buffered_operations()
         retry_until_ok(self.elastic.indices.refresh, index="")
-
-    def run_auto_commit(self):
-        """Periodically commit to the Elastic server."""
-        self.commit()
-        if self.auto_commit_interval not in [None, 0]:
-            Timer(self.auto_commit_interval, self.run_auto_commit).start()
 
     @wrap_exceptions
     def get_last_doc(self):

--- a/tests/test_elastic_doc_manager.py
+++ b/tests/test_elastic_doc_manager.py
@@ -17,6 +17,8 @@ import base64
 import sys
 import time
 
+from functools import wraps
+
 sys.path[0:0] = [""]
 
 from mongo_connector import errors
@@ -29,6 +31,25 @@ from mongo_connector.util import retry_until_ok
 from tests import unittest, elastic_pair
 from tests.test_elastic import ElasticsearchTestCase
 from elasticsearch.helpers import bulk
+
+
+def disable_auto_refresh(func):
+    """Disable default 1 second auto refresh in Elasticsearch for a test.
+
+    https://www.elastic.co/guide/en/elasticsearch/reference/current/indices
+    -update-settings.html
+    """
+    @wraps(func)
+    def _disable_auto_refresh(self, *args, **kwargs):
+        try:
+            self.elastic_conn.indices.put_settings(
+                index='test', body={'index': {'refresh_interval': '-1'}})
+            return func(self, *args, **kwargs)
+        finally:
+            self.elastic_conn.indices.put_settings(
+                index='test', body={'index': {'refresh_interval': '1s'}})
+
+    return _disable_auto_refresh
 
 
 class TestElasticDocManager(ElasticsearchTestCase):
@@ -254,38 +275,80 @@ class TestElasticDocManager(ElasticsearchTestCase):
         self.assertIn('1', result_ids)
         self.assertIn('2', result_ids)
 
+    @disable_auto_refresh
     def test_elastic_commit(self):
         """Test the auto_commit_interval attribute."""
-        docc = {'_id': '3', 'name': 'Waldo'}
-
-        # Disable 1s refresh in elasticsearch
-        # https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html
-        disable_refresh_body = {'index': {'refresh_interval': '-1'}}
-        self.elastic_conn.indices.put_settings(index='test', body=disable_refresh_body)
+        doc = {'_id': '3', 'name': 'Waldo'}
 
         # test cases:
-        # -1 = no autocommit
+        # None = no autocommit
         # 0 = commit immediately
         # x > 0 = commit within x seconds
-        for autocommit_interval in [None, 0, 1, 2]:
-            docman = DocManager(elastic_pair, auto_commit_interval=autocommit_interval)
-            docman.upsert(docc, *TESTARGS)
-            if autocommit_interval is None:
-                docman.commit()
-            else:
+        for commit_interval in [None, 0, 2, 8]:
+            docman = DocManager(elastic_pair,
+                                auto_commit_interval=commit_interval)
+            docman.upsert(doc, *TESTARGS)
+            if commit_interval:
                 # Allow just a little extra time
-                time.sleep(autocommit_interval + 1)
+                time.sleep(commit_interval + 2)
             results = list(self._search())
-            self.assertEqual(len(results), 1,
-                             "should commit document with "
-                             "auto_commit_interval = %s" % str(
-                                 autocommit_interval))
-            self.assertEqual(results[0]["name"], "Waldo")
+            if commit_interval is None:
+                self.assertEqual(len(results), 0,
+                                 "should not commit document with "
+                                 "auto_commit_interval = None")
+            else:
+                self.assertEqual(len(results), 1,
+                                 "should commit document with "
+                                 "auto_commit_interval = %s" % (
+                                 commit_interval,))
+                self.assertEqual(results[0]["name"], "Waldo")
             docman.stop()
             self._remove()
             retry_until_ok(self.elastic_conn.indices.refresh, index="")
-        enable_refresh_body = {"index": {"refresh_interval": "1s"}}
-        self.elastic_conn.indices.put_settings(index="test", body=enable_refresh_body)
+
+    @disable_auto_refresh
+    def test_auto_send_interval(self):
+        """Test the auto_send_interval
+
+        auto_send_interval should control the amount of time to wait before
+        sending (but not committing) buffered operations.
+        """
+        doc = {'_id': '3', 'name': 'Waldo'}
+
+        # test cases:
+        # None, 0 = no auto send
+        # x > 0 = send buffered operations within x seconds
+        for send_interval in [None, 0, 3, 8]:
+            docman = DocManager(elastic_pair,
+                                autoSendInterval=send_interval,
+                                auto_commit_interval=None)
+            docman.upsert(doc, *TESTARGS)
+            if send_interval:
+                # Allow just a little extra time
+                time.sleep(send_interval + 2)
+            results = list(self._search())
+            self.assertEqual(
+                len(results), 0,
+                "documents should not be commited with "
+                "auto_commit_interval=None and auto_commit_interval=%s" % (
+                    send_interval,))
+            # Commit the possibly sent changes and search again
+            retry_until_ok(self.elastic_conn.indices.refresh, index="")
+            results = list(self._search())
+            if not send_interval:
+                self.assertEqual(
+                    len(results), 0,
+                    "should not send document with auto_send_interval=%s" % (
+                        send_interval,))
+            else:
+                self.assertEqual(
+                    len(results), 1,
+                    "should send document with auto_send_interval=%s" % (
+                        send_interval,))
+                self.assertEqual(results[0]["name"], "Waldo")
+            docman.stop()
+            self._remove()
+            retry_until_ok(self.elastic_conn.indices.refresh, index="")
 
     def test_get_last_doc(self):
         """Test the get_last_doc method.


### PR DESCRIPTION
Add `docManagers.<index>.autoSendInterval` config option.

This is a backport of these two elastic2-doc-manager changes: https://github.com/mongodb-labs/elastic2-doc-manager/pull/35 and https://github.com/mongodb-labs/elastic2-doc-manager/pull/37 
